### PR TITLE
Add qcow support to sleuthkit

### DIFF
--- a/decaf/configure
+++ b/decaf/configure
@@ -194,6 +194,7 @@ opengl=""
 zlib="yes"
 guest_agent="yes"
 libiscsi=""
+libqcow="no"
 
 # parse CC options first
 for opt do
@@ -536,6 +537,9 @@ for opt do
   --interp-prefix=*) interp_prefix="$optarg"
   ;;
   --source-path=*)
+  ;;
+  # Add qcow support --Ren
+  --libqcow-path=*) libqcow="$optarg"
   ;;
   --cross-prefix=*)
   ;;
@@ -1131,6 +1135,8 @@ echo "  --enable-tcg-llvm        enable TCG-to-LLVM translation"
 # AWH - VMI enable
 echo "  --disable-vmi            disable VMI support"
 echo "  --enable-vmi             enable VMI support (default)"
+# Add qcow support --Ren
+echo "  --libqcow-path           path to QCOW library"
 echo ""
 echo "NOTE: The object files are built at the place where configure is launched"
 exit 1
@@ -3951,6 +3957,7 @@ fi
 
 echo "Configuring Sleuthkit now! Please wait"
 cd ./shared/sleuthkit
-./configure --disable-java --enable-silent-rules --prefix=$PWD > /dev/null 2>&1
+./bootstrap > /dev/null 2>&1
+./configure --disable-java --enable-silent-rules --prefix=$PWD --with-libqcow=$libqcow > /dev/null 2>&1
 cd ../..
 echo "DECAF configuration complete! Type 'make' to begin building."

--- a/decaf/shared/sleuthkit/bootstrap
+++ b/decaf/shared/sleuthkit/bootstrap
@@ -1,0 +1,5 @@
+#!/bin/sh
+aclocal \
+    && (libtoolize --force || glibtoolize --force) \
+    && automake --foreign --add-missing --copy \
+    && autoconf

--- a/decaf/shared/sleuthkit/configure.ac
+++ b/decaf/shared/sleuthkit/configure.ac
@@ -242,6 +242,32 @@ dnl status message and set X_JNI for use in Makefile
 AS_IF([test "x$JNI_CPPFLAGS" != x && test "x$ANT_FOUND" != x && test "x$JAVA" != x], [ax_java_support=yes], [ax_java_support=no])
 AM_CONDITIONAL([X_JNI],[test "x$ax_java_support" == "xyes"])
 
+# Check if we should link libqcow.
+AC_ARG_WITH([libqcow],
+    [AS_HELP_STRING([--without-libqcow],[Do not use libqcow even if it is installed])]
+    [AS_HELP_STRING([--with-libqcow=dir],[Specify that libqcow is installed in directory 'dir'])],
+    # If --with-libqcow or --without-libqcow is given
+    [],
+    # if nothing was specified, default to a test
+    [with_libqcow=yes])
+
+# check for the lib if they did not specify no
+AS_IF([test "x$with_libqcow" != "xno"],
+    # Test the dir if they specified something beyond yes/no
+    [AS_IF([test "x$with_libqcow" != "xyes"],
+        [AS_IF([test -d ${with_libqcow}/include],
+            [CFLAGS="$CFLAGS -I${with_libqcow}/include"
+                LDFLAGS="$LDFLAGS -L${with_libqcow}/lib"],
+            # Dir given was not correct
+            [AC_MSG_FAILURE([libqcow directory not found at ${with_libqcow}])])
+        ]
+    )]
+    # Check for the header file first to make sure they have the dev install
+    [AC_CHECK_HEADERS([libqcow.h], 
+      [AC_CHECK_LIB([qcow], [libqcow_file_open])]
+    )]
+)
+
 AC_CONFIG_COMMANDS([tsk/tsk_incs.h],
     [echo "#ifndef _TSK_INCS_H" > tsk/tsk_incs.h
     echo "#define _TSK_INCS_H" >> tsk/tsk_incs.h

--- a/decaf/shared/sleuthkit/tsk/img/Makefile.am
+++ b/decaf/shared/sleuthkit/tsk/img/Makefile.am
@@ -3,7 +3,7 @@ EXTRA_DIST = .indent.pro
 
 noinst_LTLIBRARIES = libtskimg.la
 libtskimg_la_SOURCES = img_open.c img_types.c raw.c raw.h \
-    aff.c aff.h ewf.c ewf.h tsk_img_i.h img_io.c mult_files.c
+    aff.c aff.h ewf.c ewf.h qcow.c qcow.h tsk_img_i.h img_io.c mult_files.c
 
 indent:
 	indent *.c *.h

--- a/decaf/shared/sleuthkit/tsk/img/img_open.c
+++ b/decaf/shared/sleuthkit/tsk/img/img_open.c
@@ -27,6 +27,10 @@ typedef int bool;
 #include "ewf.h"
 #endif
 
+#if HAVE_LIBQCOW
+#include "qcow.h"
+#endif
+
 
 
 /**
@@ -114,7 +118,7 @@ tsk_img_open(int num_img,
      */
     if (type == TSK_IMG_TYPE_DETECT) {
         TSK_IMG_INFO *img_set = NULL;
-#if HAVE_LIBAFFLIB || HAVE_LIBEWF
+#if HAVE_LIBAFFLIB || HAVE_LIBEWF || HAVE_LIBQCOW
         char *set = NULL;
 #endif
 
@@ -155,6 +159,26 @@ tsk_img_open(int num_img,
                 tsk_error_reset();
                 tsk_error_set_errno(TSK_ERR_IMG_UNKTYPE);
                 tsk_error_set_errstr("EWF or %s", set);
+                return NULL;
+            }
+        }
+        else {
+            tsk_error_reset();
+        }
+#endif
+
+#if HAVE_LIBQCOW
+        if ((img_info = qcow_open(num_img, images, a_ssize)) != NULL) {
+            if (set == NULL) {
+                set = "QCOW";
+                img_set = img_info;
+            }
+            else {
+                img_set->close(img_set);
+                img_info->close(img_info);
+                tsk_error_reset();
+                tsk_errno = TSK_ERR_IMG_UNKTYPE;
+                snprintf(tsk_errstr, TSK_ERRSTR_L, "QCOW or %s", set);
                 return NULL;
             }
         }

--- a/decaf/shared/sleuthkit/tsk/img/img_types.c
+++ b/decaf/shared/sleuthkit/tsk/img/img_types.c
@@ -41,6 +41,9 @@ static IMG_TYPES img_open_table[] = {
 #if HAVE_LIBEWF
     {"ewf", TSK_IMG_TYPE_EWF_EWF, "Expert Witness format (encase)"},
 #endif
+#if HAVE_LIBQCOW
+    {"qcow", TSK_IMG_TYPE_QCOW_QCOW, "QEMU Copy-On-Write"},
+#endif
     {0},
 };
 

--- a/decaf/shared/sleuthkit/tsk/img/qcow.c
+++ b/decaf/shared/sleuthkit/tsk/img/qcow.c
@@ -1,0 +1,333 @@
+/*
+ * The Sleuth Kit - Add on for QEMU Copy-On-Write (QCOW) image support
+ *
+ * Copyright (c) 2011 Joachim Metz <jbmetz@users.sourceforge.net>
+ *
+ * qcow
+ *
+ * This software is distributed under the Common Public License 1.0
+ */
+
+/** \file qcow.c
+ * Internal code for TSK to interface with libqcow.
+ */
+
+#include "tsk_img_i.h"
+
+#if HAVE_LIBQCOW
+
+#include "qcow.h"
+
+#define TSK_QCOW_ERROR_STRING_SIZE	512
+
+static \
+ssize_t qcow_image_read(
+         TSK_IMG_INFO *img_info,
+         TSK_OFF_T offset,
+         char *buffer,
+         size_t size )
+{
+	char error_string[ TSK_QCOW_ERROR_STRING_SIZE ];
+
+	IMG_QCOW_INFO *qcow_info    = (IMG_QCOW_INFO *) img_info;
+	libqcow_error_t *qcow_error = NULL;
+	ssize_t read_count          = 0;
+
+	if( tsk_verbose != 0 )
+	{
+		tsk_fprintf(
+		 stderr,
+		 "qcow_read: byte offset: %" PRIuOFF " len: %" PRIuSIZE "\n",
+		 offset,
+		 size );
+	}
+	if( offset > img_info->size )
+	{
+		tsk_error_reset();
+
+		tsk_errno = TSK_ERR_IMG_READ_OFF;
+
+		snprintf(
+		 tsk_errstr,
+		 TSK_ERRSTR_L,
+		 "split_read - %" PRIuOFF,
+		 offset );
+
+		return( -1 );
+	}
+	read_count = libqcow_file_read_random(
+	              qcow_info->file,
+	              buffer,
+	              size,
+	              offset,
+	              &qcow_error );
+
+	if( read_count < 0 )
+	{
+		tsk_error_reset();
+
+		tsk_errno = TSK_ERR_IMG_READ;
+
+		if( libqcow_error_backtrace_sprint(
+		     qcow_error,
+		     error_string,
+		     TSK_QCOW_ERROR_STRING_SIZE ) == -1 )
+		{
+			snprintf(
+			 tsk_errstr,
+			 TSK_ERRSTR_L,
+			 "qcow_read - offset: %" PRIuOFF " - len: %" PRIuSIZE " - %s",
+			 offset,
+			 size,
+			 strerror( errno ) );
+		}
+		else
+		{
+			snprintf(
+			 tsk_errstr,
+			 TSK_ERRSTR_L,
+			 "qcow_read - offset: %" PRIuOFF " - len: %" PRIuSIZE "\n%s",
+			 offset,
+			 size,
+			 error_string );
+		}
+                libqcow_error_free(
+                 &qcow_error );
+
+		return( -1 );
+	}
+	return( read_count );
+}
+
+static \
+void qcow_image_imgstat(
+      TSK_IMG_INFO *img_info,
+      FILE * hFile )
+{
+	tsk_fprintf(
+	 hFile,
+	 "IMAGE FILE INFORMATION\n"
+	 "--------------------------------------------\n"
+	 "Image Type:\t\tqcow\n"
+	 "\nSize of data in bytes:\t%" PRIuOFF "\n",
+	 img_info->size );
+
+	return;
+}
+
+static \
+void qcow_image_close(
+      TSK_IMG_INFO *img_info )
+{
+	IMG_QCOW_INFO *qcow_info = (IMG_QCOW_INFO *) img_info;
+
+	libqcow_file_close(
+	 qcow_info->file,
+	 NULL );
+	libqcow_file_free(
+	 &( qcow_info->file ),
+	 NULL );
+	free(
+	 img_info );
+}
+
+TSK_IMG_INFO *qcow_open(
+               int num_img,
+               const TSK_TCHAR * const images[],
+               unsigned int a_ssize )
+{
+	char error_string[ TSK_QCOW_ERROR_STRING_SIZE ];
+
+	IMG_QCOW_INFO *qcow_info    = NULL;
+	libqcow_error_t *qcow_error = NULL;
+	TSK_IMG_INFO *img_info      = NULL;
+
+	qcow_info = (IMG_QCOW_INFO *) tsk_malloc(
+	                               sizeof( IMG_QCOW_INFO ) );
+
+	if( qcow_info == NULL )
+	{
+		return NULL;
+	}
+	img_info = (TSK_IMG_INFO *) qcow_info;
+
+	/* Check the file signature before we call the library open
+	 */
+#if defined( TSK_WIN32 )
+	if( libqcow_check_file_signature_wide(
+	     images[ 0 ],
+	     &qcow_error ) != 1 )
+#else
+	if( libqcow_check_file_signature(
+	     images[ 0 ],
+	     &qcow_error ) != 1 )
+#endif
+	{
+		tsk_error_reset();
+
+		tsk_errno = TSK_ERR_IMG_MAGIC;
+
+		if( libqcow_error_backtrace_sprint(
+		     qcow_error,
+		     error_string,
+		     TSK_QCOW_ERROR_STRING_SIZE ) == -1 )
+		{
+			snprintf(
+			 tsk_errstr,
+			 TSK_ERRSTR_L,
+			 "qcow_open: Not an QCOW file" );
+		}
+		else
+		{
+			snprintf(
+			 tsk_errstr,
+			 TSK_ERRSTR_L,
+			 "qcow_open: Not an QCOW file\n%s",
+			 error_string );
+		}
+                libqcow_error_free(
+                 &qcow_error );
+
+		free(
+		 qcow_info );
+
+		if(tsk_verbose != 0 )
+		{
+			tsk_fprintf(
+			 stderr,
+			 "Not an QCOW file\n" );
+		}
+		return( NULL );
+	}
+	if( libqcow_file_initialize(
+	     &( qcow_info->file ),
+	     &qcow_error ) != 1 )
+	{
+        	tsk_error_reset();
+
+	        tsk_errno = TSK_ERR_IMG_OPEN;
+
+		if( libqcow_error_backtrace_sprint(
+		     qcow_error,
+		     error_string,
+		     TSK_QCOW_ERROR_STRING_SIZE ) == -1 )
+		{
+			snprintf(
+			 tsk_errstr,
+			 TSK_ERRSTR_L,
+			 "qcow_open file: %" PRIttocTSK ": Error opening",
+			 images[ 0 ] );
+		}
+		else
+		{
+			snprintf(
+			 tsk_errstr,
+			 TSK_ERRSTR_L,
+			 "qcow_open file: %" PRIttocTSK ": Error opening\n%s",
+			 images[ 0 ],
+			 error_string );
+		}
+		free(
+		 qcow_info);
+
+		if( tsk_verbose != 0 )
+		{
+			tsk_fprintf(
+			 stderr,
+			 "Unable to create QCOW file\n" );
+		}
+		return( NULL );
+	}
+#if defined( TSK_WIN32 )
+	if( libqcow_file_open_wide(
+	     qcow_info->file,
+	     images[ 0 ],
+	     LIBQCOW_OPEN_READ,
+	     &qcow_error ) != 1 )
+#else
+	if( libqcow_file_open(
+	     qcow_info->file,
+	     images[ 0 ],
+	     LIBQCOW_OPEN_READ,
+	     &qcow_error ) != 1 )
+#endif
+	{
+        	tsk_error_reset();
+
+	        tsk_errno = TSK_ERR_IMG_OPEN;
+
+	        snprintf(
+		 tsk_errstr,
+		 TSK_ERRSTR_L,
+		 "qcow_open file: %" PRIttocTSK ": Error opening",
+		 images[ 0 ] );
+
+	        free(
+		 qcow_info );
+
+		if( tsk_verbose != 0 )
+		{
+			tsk_fprintf(
+			 stderr,
+			 "Error opening QCOW file\n" );
+		}
+		return( NULL );
+	}
+	if( libqcow_file_get_media_size(
+	     qcow_info->file,
+	     (size64_t *) &( img_info->size ),
+	     &qcow_error ) != 1 )
+	{
+		tsk_error_reset();
+
+		tsk_errno = TSK_ERR_IMG_OPEN;
+
+		if( libqcow_error_backtrace_sprint(
+		     qcow_error,
+		     error_string,
+		     TSK_QCOW_ERROR_STRING_SIZE ) == -1 )
+		{
+			snprintf(
+			 tsk_errstr,
+			 TSK_ERRSTR_L,
+			 "qcow_open file: %" PRIttocTSK ": Error getting size of image",
+			 images[ 0 ] );
+		}
+		else
+		{
+			snprintf(
+			 tsk_errstr,
+			 TSK_ERRSTR_L,
+			 "qcow_open file: %" PRIttocTSK ": Error getting size of image\n%s",
+			 images[ 0 ],
+			 error_string );
+		}
+		free(
+		 qcow_info );
+
+		if( tsk_verbose != 0 )
+		{
+			tsk_fprintf(
+			 stderr,
+			 "Error getting size of QCOW file\n" );
+		}
+		return( NULL );
+	}
+	if( a_ssize != 0 )
+	{
+		img_info->sector_size = a_ssize;
+	}
+	else
+	{
+		img_info->sector_size = 512;
+	}
+	img_info->itype   = TSK_IMG_TYPE_QCOW_QCOW;
+	img_info->read    = &qcow_image_read;
+	img_info->close   = &qcow_image_close;
+	img_info->imgstat = &qcow_image_imgstat;
+
+	return( img_info );
+}
+
+#endif /* HAVE_LIBQCOW */
+

--- a/decaf/shared/sleuthkit/tsk/img/qcow.h
+++ b/decaf/shared/sleuthkit/tsk/img/qcow.h
@@ -1,0 +1,48 @@
+/*
+ * The Sleuth Kit - Add on for QEMU Copy-On-Write (QCOW) image support
+ *
+ * Copyright (c) 2011 Joachim Metz <jbmetz@users.sourceforge.net>
+ *
+ * This software is distributed under the Common Public License 1.0
+ */
+
+/* 
+ * Header files for QCOW-specific data structures and functions. 
+ */
+
+#if !defined( _TSK_IMG_QCOW_H )
+#define _TSK_IMG_QCOW_H
+
+#if defined( TSK_WIN32 )
+#include <config_msc.h>
+#endif
+
+#if HAVE_LIBQCOW
+
+#include <libqcow.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern \
+TSK_IMG_INFO *qcow_open(
+               int,
+               const TSK_TCHAR * const images[],
+               unsigned int a_ssize );
+
+typedef struct
+{
+	TSK_IMG_INFO img_info;
+
+	libqcow_file_t *file;
+
+} IMG_QCOW_INFO;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* HAVE_LIBQCOW */
+
+#endif

--- a/decaf/shared/sleuthkit/tsk/img/tsk_img.h
+++ b/decaf/shared/sleuthkit/tsk/img/tsk_img.h
@@ -65,6 +65,7 @@ extern "C" {
         TSK_IMG_TYPE_AFF_ANY = 0x0020,  ///< Any format supported by AFFLIB (including beta ones)
 
         TSK_IMG_TYPE_EWF_EWF = 0x0040,  ///< EWF version
+	TSK_IMG_TYPE_QCOW_QCOW = 0x0050,  ///< QCOW version
         TSK_IMG_TYPE_EXTERNAL = 0x1000,  ///< external defined format which at least implements TSK_IMG_INFO, used by pytsk
         
         QEMU_IMG             = 0x0050,   // QEMU image format support 


### PR DESCRIPTION
Added qcow format support to sleuthkit.(Joachim's patch of TSK)
It's convenience when we use sleutkit API on DECAF.