### PR TITLE
Compilation fix for Ubuntu 15.10

### DIFF
--- a/decaf/shared/linux_readelf.cpp
+++ b/decaf/shared/linux_readelf.cpp
@@ -28,6 +28,7 @@
 #include <istream>
 #include <streambuf>
 #include <sstream>
+#include <algorithm>
 #include <inttypes.h>
 #include <string>
 #include <list>

--- a/decaf/shared/procmod.cpp
+++ b/decaf/shared/procmod.cpp
@@ -13,6 +13,8 @@ http://sycurelab.ecs.syr.edu/
 If you have any questions about DECAF,please post it on
 http://code.google.com/p/decaf-platform/
 */
+#include <string>
+#include <list>
 #include "qemu-common.h"
 #include "hw/hw.h"
 #include "DECAF_main.h"
@@ -26,8 +28,6 @@ http://code.google.com/p/decaf-platform/
 #include "vmi.h"
 #include "windows_vmi.h"
 #include "shared/DECAF_types.h"
-#include <string>
-#include <list>
 #include <assert.h>
 #include <errno.h>
 #include <string.h>

--- a/decaf/shared/utils/HashtableWrapper.cpp
+++ b/decaf/shared/utils/HashtableWrapper.cpp
@@ -20,11 +20,11 @@ http://code.google.com/p/decaf-platform/
  *      Author: lok
  */
 
+#include <tr1/unordered_set>
+
 #include "HashtableWrapper.h"
 #include "Output.h"
 #include "DECAF_types.h"
-
-#include <tr1/unordered_set>
 
 using namespace std::tr1;
 


### PR DESCRIPTION
Unable to compile under Ubuntu 15.10 using gcc (Ubuntu 5.2.1-22ubuntu2) 5.2.1 20151010. Moved standard includes (e.g. - algorithm, string, list) ahead of QEMU #include statements to fix this issue.