### PR TITLE
Fixed unintialized symbol_extracted variable in VMI module.

### DIFF
--- a/decaf/shared/vmi.h
+++ b/decaf/shared/vmi.h
@@ -42,9 +42,8 @@ public:
 	unordered_map < string, uint32_t> function_map_name;
 	unsigned int inode_number;
 
-	module()
+	module() : symbols_extracted(false), inode_number(0)
 	{
-		this->inode_number = 0;
 	}
 };
 


### PR DESCRIPTION
Fixed unintialized symbols_extracted member variable in VMI module class, which may cause DECAF not extracting symbols for a module sometimes. 

Signed-off-by: Zhongjie Wang <wzj401@gmail.com>